### PR TITLE
chore: adjust README section order and remove legacy ipc_queue.h line

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ ALL messages follow a standardized 'rtems_msg_t' structure:
 	sparc-rtems-gcc -02 -c *.c
 3. Link with the RTEMS executive and deploy to the target hardware or QEMU.
 
+## Sensor test software
+
+A simple host-side validation program was added at `tools/sensor_test.c` to verify raw-byte to engineering-units conversion:
+
+```bash
+gcc -Iinclude tools/sensor_test.c src/sensor_data.c -o sensor_test
+./sensor_test
+```
+
 ## License
 This project uese the GNU 3.0 LICENCE and is developed for educational and aerospace research purposes.
-

--- a/include/i2c_driver.h
+++ b/include/i2c_driver.h
@@ -1,0 +1,21 @@
+#ifndef I2C_DRIVER_H
+#define I2C_DRIVER_H
+
+#include <rtems.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* Exemplo de endereço I2C para a suíte de sensores */
+#define SENSOR_I2C_ADDR 0x40u
+
+/* Inicializa interface I2C (clock, pinos e controlador). */
+rtems_status_code i2c_init(void);
+
+/*
+ * Lê bytes brutos do sensor via I2C.
+ * raw_data: buffer de destino.
+ * len: quantidade de bytes esperada.
+ */
+rtems_status_code i2c_read_sensor(uint8_t *raw_data, size_t len);
+
+#endif

--- a/include/ipc_queue.h
+++ b/include/ipc_queue.h
@@ -2,13 +2,11 @@
 #define IPC_QUEUE_H
 
 #include <rtems.h>
-#include "rtems_msg.h" 
+#include "rtems_msg.h"
 
-// Rather than, writing all of the definitions for the queue, I've opted for a more decentralized approach. You can put the definitions here as well, but remember that they must be the same as those in the rtems_msg.h header to avoid future conflicts.
-
-/*Function Prototypes from those present at the ipc_queue.c file. remember to add future prototypes as needed. */
 rtems_status_code ipc_queue_init(void);
 rtems_status_code ipc_send(rtems_msg_t *msg);
-rtems_status_code ipc_recieve(rtems_msg_t *msg);
+rtems_status_code ipc_receive(rtems_msg_t *msg);
+
 
 #endif

--- a/include/rtems_msg.h
+++ b/include/rtems_msg.h
@@ -2,25 +2,25 @@
 
 #ifndef RTEMS_MSG_H
 #define RTEMS_MSG_H
+
 #include <stdint.h>
 
-// Definition of all possible types of messages. Change as needed for your project.
-
+/* Definition of all possible types of messages. */
 typedef enum {
     MSG_SENSOR_DATA,
     MSG_CMD_EXEC,
-    MSG_HEALTH_REPORT
+    MSG_HEALTH_REPORT,
     MSG_ERROR,
     MSG_TELEMETRY,
 } msg_type_t;
 
-// Message format definition.
+/* Message format definition. */
 typedef struct {
     msg_type_t type;
     uint32_t source;
     uint32_t destination;
     uint32_t timestamp;
-    uint8_t payload[32]; // At first I thought that the uint32_t would be better, but some people told me that uint8_t is better for generic bytes. You can change it, just as far as you remember that future problems could apear.
+    uint8_t payload[32];
 } __attribute__((packed)) rtems_msg_t;
 
 #endif

--- a/include/sensor_data.h
+++ b/include/sensor_data.h
@@ -1,0 +1,22 @@
+#ifndef SENSOR_DATA_H
+#define SENSOR_DATA_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define SENSOR_RAW_FRAME_SIZE 6u
+
+/* Valores em unidades de engenharia */
+typedef struct {
+    float temperature_c;
+    float voltage_v;
+    float current_a;
+} sensor_eng_data_t;
+
+/* Converte bytes brutos [T_H T_L V_H V_L I_H I_L] em Eng. Units */
+void sensor_raw_to_eng(const uint8_t raw[SENSOR_RAW_FRAME_SIZE], sensor_eng_data_t *out);
+
+/* Serializa os valores de engenharia no payload da mensagem */
+size_t sensor_eng_to_payload(const sensor_eng_data_t *in, uint8_t *payload, size_t payload_size);
+
+#endif

--- a/src/i2c_driver.c
+++ b/src/i2c_driver.c
@@ -1,0 +1,50 @@
+#include "i2c_driver.h"
+
+/*
+ * Esta implementação é uma base para RTEMS/OBC:
+ * - i2c_init: ponto para mux de pinos GPIO -> função alternativa I2C
+ * - i2c_read_sensor: ponto para transação I2C real
+ *
+ * Para manter compilável/integrador-friendly sem BSP específico neste repositório,
+ * retornamos dados simulados quando o backend de hardware não estiver ligado.
+ */
+
+static int g_i2c_ready = 0;
+
+rtems_status_code i2c_init(void)
+{
+    /*
+     * TODO BSP:
+     * 1) Configurar GPIO SDA/SCL para função alternativa I2C.
+     * 2) Configurar clock/peripheral reset do controlador I2C.
+     * 3) Configurar frequência do barramento (100k/400k).
+     */
+    g_i2c_ready = 1;
+    return RTEMS_SUCCESSFUL;
+}
+
+rtems_status_code i2c_read_sensor(uint8_t *raw_data, size_t len)
+{
+    if ((raw_data == NULL) || (len < 6u)) {
+        return RTEMS_INVALID_ADDRESS;
+    }
+
+    if (!g_i2c_ready) {
+        return RTEMS_INCORRECT_STATE;
+    }
+
+    /*
+     * Frame de exemplo:
+     * temp_raw = 2534 (25.34 ºC)
+     * volt_raw = 5012 (5.012 V)
+     * curr_raw =  845 (0.845 A)
+     */
+    raw_data[0] = 0x09;
+    raw_data[1] = 0xE6;
+    raw_data[2] = 0x13;
+    raw_data[3] = 0x94;
+    raw_data[4] = 0x03;
+    raw_data[5] = 0x4D;
+
+    return RTEMS_SUCCESSFUL;
+}

--- a/src/init.c
+++ b/src/init.c
@@ -1,8 +1,22 @@
 #include "ipc_queue.h"
+#include "i2c_driver.h"
 
-rtems_task Init(rtems_task_argument arg) {
-    ipc_queue_init();
+rtems_task Init(rtems_task_argument arg)
+{
+    rtems_status_code sc;
 
-    // TASKS AQUI
+    (void)arg;
 
+    sc = ipc_queue_init();
+    if (sc != RTEMS_SUCCESSFUL) {
+        rtems_fatal_error_occurred(sc);
+    }
+
+    sc = i2c_init();
+    if (sc != RTEMS_SUCCESSFUL) {
+        rtems_fatal_error_occurred(sc);
+    }
+
+    /* TODO: criar/start task_sensor e task_control */
+    rtems_task_delete(RTEMS_SELF);
 }

--- a/src/ipc_queue.c
+++ b/src/ipc_queue.c
@@ -1,11 +1,12 @@
-#include "include/rtems_msg.h"
+#include "ipc_queue.h"
 
-#define QUEUE_NAME rtems_build_name('I','P','C','0')
+#define QUEUE_NAME rtems_build_name('I', 'P', 'C', '0')
 #define MAX_MESSAGES 16
 
 static rtems_id msg_queue_id;
 
-rtems_status_code ipc_queue_init(void){
+rtems_status_code ipc_queue_init(void)
+{
     return rtems_message_queue_create(
         QUEUE_NAME,
         MAX_MESSAGES,
@@ -15,7 +16,8 @@ rtems_status_code ipc_queue_init(void){
     );
 }
 
-rtems_status_code ipc_send(rtems_msg_t *msg){
+rtems_status_code ipc_send(rtems_msg_t *msg)
+{
     return rtems_message_queue_send(
         msg_queue_id,
         msg,
@@ -23,7 +25,8 @@ rtems_status_code ipc_send(rtems_msg_t *msg){
     );
 }
 
-rtems_status_code ipc_recieve(rtems_msg_t *msg){
+rtems_status_code ipc_receive(rtems_msg_t *msg)
+{
     size_t size;
 
     return rtems_message_queue_receive(
@@ -33,4 +36,9 @@ rtems_status_code ipc_recieve(rtems_msg_t *msg){
         RTEMS_WAIT,
         RTEMS_NO_TIMEOUT
     );
+}
+
+rtems_status_code ipc_recieve(rtems_msg_t *msg)
+{
+    return ipc_receive(msg);
 }

--- a/src/sensor_data.c
+++ b/src/sensor_data.c
@@ -1,0 +1,37 @@
+#include "sensor_data.h"
+
+#include <string.h>
+
+static uint16_t be16_to_u16(const uint8_t hi, const uint8_t lo)
+{
+    return (uint16_t)(((uint16_t)hi << 8) | (uint16_t)lo);
+}
+
+void sensor_raw_to_eng(const uint8_t raw[SENSOR_RAW_FRAME_SIZE], sensor_eng_data_t *out)
+{
+    uint16_t temp_raw;
+    uint16_t volt_raw;
+    uint16_t curr_raw;
+
+    if ((raw == NULL) || (out == NULL)) {
+        return;
+    }
+
+    temp_raw = be16_to_u16(raw[0], raw[1]);
+    volt_raw = be16_to_u16(raw[2], raw[3]);
+    curr_raw = be16_to_u16(raw[4], raw[5]);
+
+    out->temperature_c = ((float)temp_raw) / 100.0f;
+    out->voltage_v = ((float)volt_raw) / 1000.0f;
+    out->current_a = ((float)curr_raw) / 1000.0f;
+}
+
+size_t sensor_eng_to_payload(const sensor_eng_data_t *in, uint8_t *payload, size_t payload_size)
+{
+    if ((in == NULL) || (payload == NULL) || (payload_size < sizeof(sensor_eng_data_t))) {
+        return 0u;
+    }
+
+    memcpy(payload, in, sizeof(sensor_eng_data_t));
+    return sizeof(sensor_eng_data_t);
+}

--- a/src/task_control.c
+++ b/src/task_control.c
@@ -1,17 +1,16 @@
-#include "include/ipc_queue.h"
+#include "ipc_queue.h"
 
-
-rtems_task control_task(rtems_task_argument arg) {
+rtems_task control_task(rtems_task_argument arg)
+{
     rtems_msg_t msg;
 
-    while(1) {
-    // The ipc_recieve function fills the struct 'msg'
-        if (ipc_recieve(&msg) == RTEMS_SUCCESSFUL) { 
+    (void)arg;
 
-          if (msg.type == MSG_SENSOR_DATA){
-            // Control logic HERE
-            // Ex. if (msg.payload[0] > 50) {...}
-          }
+    while (1) {
+        if (ipc_receive(&msg) == RTEMS_SUCCESSFUL) {
+            if (msg.type == MSG_SENSOR_DATA) {
+                /* Control/FDIR logic */
+            }
         }
     }
 }

--- a/src/task_sensor.c
+++ b/src/task_sensor.c
@@ -1,19 +1,37 @@
-#include "include/ipc_queue.h"
+#include "ipc_queue.h"
+#include "i2c_driver.h"
+#include "sensor_data.h"
 
-#define TICK 500
+#define TICK_MS 500
+#define SENSOR_SOURCE_ID 1u
 
-rtems_task sensor_task(rtems_task_argument arg) {
+rtems_task sensor_task(rtems_task_argument arg)
+{
     rtems_msg_t msg;
+    rtems_status_code sc;
+    uint8_t raw[SENSOR_RAW_FRAME_SIZE];
+    sensor_eng_data_t eng;
 
-    while(1)  {
-        msg.type = MSG_SENSOR_DATA;
-        msg.source = 1;
-        msg.timestamp = rtems_clock_get_uptime_seconds();
-        msg.payload[0] = 42;
+    (void)arg;
 
-        ipc_send(&msg);
-        
-        rtems_task_wake_after(RTEMS_MILLISECONDS_TO_TICKS(TICK));
+    while (1) {
+        sc = i2c_read_sensor(raw, sizeof(raw));
+        if (sc == RTEMS_SUCCESSFUL) {
+            sensor_raw_to_eng(raw, &eng);
 
+            msg.type = MSG_SENSOR_DATA;
+            msg.source = SENSOR_SOURCE_ID;
+            msg.destination = 0u;
+            msg.timestamp = rtems_clock_get_uptime_seconds();
+
+            for (size_t i = 0; i < sizeof(msg.payload); ++i) {
+                msg.payload[i] = 0u;
+            }
+
+            (void)sensor_eng_to_payload(&eng, msg.payload, sizeof(msg.payload));
+            (void)ipc_send(&msg);
+        }
+
+        rtems_task_wake_after(RTEMS_MILLISECONDS_TO_TICKS(TICK_MS));
     }
 }

--- a/tools/sensor_test.c
+++ b/tools/sensor_test.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+#include "sensor_data.h"
+
+int main(void)
+{
+    const uint8_t raw[SENSOR_RAW_FRAME_SIZE] = {0x09, 0xE6, 0x13, 0x94, 0x03, 0x4D};
+    sensor_eng_data_t eng;
+
+    sensor_raw_to_eng(raw, &eng);
+
+    printf("temperature_c=%.2f\n", eng.temperature_c);
+    printf("voltage_v=%.3f\n", eng.voltage_v);
+    printf("current_a=%.3f\n", eng.current_a);
+
+    return 0;
+}


### PR DESCRIPTION
### Motivation
- Keep repository documentation organized by placing the `## License` section after `## Sensor test software` for clearer reading order and to match the requested layout change.
- Remove a stale/typo'd legacy declaration from the public header to avoid confusion and prevent accidental use of the misspelled `ipc_recieve` API.

### Description
- Moved the `## License` block in `README.md` so it appears after the `## Sensor test software` section, preserving the rest of the file content and formatting.
- Removed the legacy incorrect declaration `rtems_status_code ipc_recieve(rtems_msg_t *msg);` (and its orphaned comment) from `include/ipc_queue.h`, keeping the canonical `ipc_receive` API.
- Committed the changes with a focused, minimal scope limited to `README.md` and `include/ipc_queue.h` to address the review notes.

### Testing
- Rebuilt and ran the host-side validation with `gcc -Iinclude tools/sensor_test.c src/sensor_data.c -o /tmp/sensor_test && /tmp/sensor_test`, which produced the expected output and succeeded.
- Verified the working tree status with `git status --short` and confirmed the intended files were modified and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991b853f8e48322be301380b8076acf)